### PR TITLE
Update migration

### DIFF
--- a/database/migrations/2018_01_03_000000_create_banks_table.php
+++ b/database/migrations/2018_01_03_000000_create_banks_table.php
@@ -19,7 +19,7 @@ class CreateBanksTable extends Migration
             $table->increments('id');
             $table->string('name', 120)->unique();
             $table->string('website')->nullable();
-            $table->integer('compensation_code', 4)->nullable();
+            $table->integer('compensation_code')->nullable();
             $table->timestamps();
             $table->softDeletes();
 


### PR DESCRIPTION
Correction for error: "SQLSTATE[42000]: Syntax error or access violation: 1075 Incorrect table definition; there can be only one auto column and it must be defined as a key"